### PR TITLE
Docker registry migration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ node_js:
 branches:
   only:
     - master
-    # TODO: remove this line after testing
-    - feature/migrate
 
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ node_js:
 branches:
   only:
     - master
+    # TODO: remove this line after testing
+    - feature/migrate
 
 services:
   - docker
@@ -23,7 +25,7 @@ after_success:
       pip install --user awscli;
       export PATH=$PATH:$HOME/.local/bin;
       account_id=$(aws sts get-caller-identity --output text --query 'Account');
-      region_id=us-east-1;
+      region_id=us-west-2;
       registry_url=${account_id}.dkr.ecr.${region_id}.amazonaws.com/wallet;
       eval $(aws ecr get-login --no-include-email --region ${region_id});
       docker build -t ${registry_url} .;


### PR DESCRIPTION
This PR changes the docker registry from us-east-1 to us-west-2 as part of the migration plan. See the internal doc Zilliqa Docker Registry Migration (us-east-1 to us-west-2) for further information.