### PR TITLE
chore(): upgrade to non-vulnerable bootstrap

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3720,9 +3720,9 @@
       }
     },
     "bootstrap": {
-      "version": "4.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.0.0-beta.2.tgz",
-      "integrity": "sha512-DzGtdTlKbrMoGMpz0LigKSqJ+MgtFKxA791PU/q062OlRG0HybNZcTLH7rpDAmLS66Y3esN9yzKHLLbqa5UR3w=="
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.1.3.tgz",
+      "integrity": "sha512-rDFIzgXcof0jDyjNosjv4Sno77X4KuPeFxG2XZZv1/Kc8DRVGVADdoQyyOVDwPqL36DDmtCQbrpMCqvpPLJQ0w=="
     },
     "brace-expansion": {
       "version": "1.1.8",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@zilliqa-js/util": "^0.2.6",
     "aes-js": "^3.1.0",
     "bcrypto": "^1.1.0",
-    "bootstrap": "4.0.0-beta.2",
+    "bootstrap": "^4.1.3",
     "core-js": "^2.5.4",
     "font-awesome": "^4.7.0",
     "hoek": "^5.0.3",


### PR DESCRIPTION
This upgrades from `bootstrap@^4.0.0-beta`, which had a vulnerability.